### PR TITLE
Fix groupid

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ initializr:
         - name: Blossom Core
           id: blossom-starter-basic
           description: Blossom basic starter (no web interface)
-          groupId: com.blossom_project
+          groupId: com.blossom-project
           artifactId: blossom-starter-basic
     - name: Interfaces
       description: Blossom interfaces
@@ -18,12 +18,12 @@ initializr:
         - name: Blossom UI Web
           id: blossom-starter-ui-web
           description: Blossom UI Web starter (Back-office)
-          groupId: com.blossom_project
+          groupId: com.blossom-project
           artifactId: blossom-starter-ui-web
         - name: Blossom UI Api
           id: blossom-starter-ui-api
           description: Blossom UI Api starter (Back-office)
-          groupId: com.blossom_project
+          groupId: com.blossom-project
           artifactId: blossom-starter-ui-api
     - name: Utilities
       description: Blossom modules to add some utility features to Blossom
@@ -31,7 +31,7 @@ initializr:
         - name: Business Process Manager
           id: blossom-starter-filemanager
           description: Add a Business Process Manager to Blossom (Camunda)
-          groupId: com.blossom_project
+          groupId: com.blossom-project
           artifactId: blossom-starter-bpmn
     - name: Functionnalities
       description: Blossom modules to add some functionnality to your app'
@@ -39,10 +39,10 @@ initializr:
         - name: File Manager
           id: blossom-starter-filemanager
           description: File storing and serving feature and tools
-          groupId: com.blossom_project
+          groupId: com.blossom-project
           artifactId: blossom-starter-filemanager
         - name: Articles
           id: blossom-starter-articles
           description: Richtext articles and front serving
-          groupId: com.blossom_project
+          groupId: com.blossom-project
           artifactId: blossom-starter-articles


### PR DESCRIPTION
New initializer uses com.blossom_project for group Ids, when it should be com.blossom-project