### PR TITLE
Set maven war plugin version to 3.2.0

### DIFF
--- a/src/main/java/com/blossomproject/showcase/initializr/model/ProjectGenerator.java
+++ b/src/main/java/com/blossomproject/showcase/initializr/model/ProjectGenerator.java
@@ -192,12 +192,7 @@ public class ProjectGenerator {
     if (projectConfiguration.getPackagingMode() == PACKAGING_MODE.WAR) {
       Plugin warPlugin = new Plugin();
       warPlugin.setArtifactId("maven-war-plugin");
-
-      Xpp3Dom warConfiguration = new Xpp3Dom("configuration");
-      Xpp3Dom failOnMissingWebXml = new Xpp3Dom("failOnMissingWebXml");
-      failOnMissingWebXml.setValue(Boolean.FALSE.toString());
-      warConfiguration.addChild(failOnMissingWebXml);
-      warPlugin.setConfiguration(warConfiguration);
+      warPlugin.setVersion(version.getMavenWarPlugin());
 
       build.addPlugin(warPlugin);
     }

--- a/src/main/java/com/blossomproject/showcase/initializr/model/Version.java
+++ b/src/main/java/com/blossomproject/showcase/initializr/model/Version.java
@@ -7,6 +7,7 @@ public class Version {
   private String blossom;
   private String springboot;
   private String kotlin;
+  private String mavenWarPlugin;
 
   public String getBlossom() {
     return blossom;
@@ -30,5 +31,13 @@ public class Version {
 
   public void setKotlin(String kotlin) {
     this.kotlin = kotlin;
+  }
+
+  public String getMavenWarPlugin() {
+    return mavenWarPlugin;
+  }
+
+  public void setMavenWarPlugin(String mavenWarPlugin) {
+    this.mavenWarPlugin = mavenWarPlugin;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ initializr:
     - blossom: 1.0.0-SNAPSHOT
       springboot: 2.0.0.RC2
       kotlin: 1.2.21
+      maven-war-plugin: 3.2.0
   groups:
     - name: Core
       description: Blossom core functionalities


### PR DESCRIPTION
Avoids maven warnings that the war plugin does not set a version, causing the pom.xml to be invalid, using the (currently) latest version : https://maven.apache.org/plugins/maven-war-plugin/

Also, starting from version 3.0.0 of the maven war plugin, "failOnMissingWebXml" default value is "false", so we do not need to explicitly set it anymore.