### PR TITLE
Update documentation mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <name>Blossom Initializr</name>
   <description>Contains Blossom project generator, documentation and showcase interfaces.</description>
   <properties>
-    <blossom.version>1.1.0-SNAPSHOT</blossom.version>
+    <blossom.version>1.1.0.M3</blossom.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
   <name>Blossom Initializr</name>
   <description>Contains Blossom project generator, documentation and showcase interfaces.</description>
   <properties>
-    <blossom.version>1.0.0</blossom.version>
+    <blossom.version>1.1.0-SNAPSHOT</blossom.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <springboot.version>2.0.1.RELEASE</springboot.version>
+    <springboot.version>2.0.4.RELEASE</springboot.version>
     <codemodel.version>2.6</codemodel.version>
     <mavenmodel.version>3.5.0</mavenmodel.version>
     <kotlinpoet.version>0.6.0</kotlinpoet.version>

--- a/src/main/resources/static/css/style-documentation.css
+++ b/src/main/resources/static/css/style-documentation.css
@@ -1,0 +1,12 @@
+.modal-dialog {
+  width: 90%;
+  height: 90%;
+}
+
+.modal-content {
+  height: auto;
+  min-height: 100%;
+  max-height: 100%;
+  border-radius: 0;
+  overflow: scroll;
+}

--- a/src/main/resources/templates/documentation.ftl
+++ b/src/main/resources/templates/documentation.ftl
@@ -1,8 +1,9 @@
-<#import "master.ftl" as master/>
+<#import "master.ftl" as master>
+<#import "/blossom/utils/modal.ftl" as modal>
 
 <#macro widgetFeature title link icon>
 <div class="col-md-6 col-lg-4">
-  <a href="${link}">
+  <a data-toggle="modal" href="#${title?replace(' ', '-')}">
     <div class="widget widget-feature p-lg text-center">
       <div class="m-b-md">
         <i class="${icon}"></i>
@@ -13,9 +14,12 @@
     </div>
   </a>
 </div>
+<@modal.large id="${title?replace(' ', '-')}" href="${link}"/>
 </#macro>
 
 <@master.default>
+<link href="/css/style-documentation.css" rel="stylesheet">
+
 <section id="headline" class="container">
   <div class="row">
     <div class="col-lg-12 text-center">

--- a/src/main/resources/templates/master.ftl
+++ b/src/main/resources/templates/master.ftl
@@ -68,7 +68,6 @@
 </#macro>
 
 <#macro feature title javadocLink="">
-  <@default>
   <style>
     .CodeMirror{
       margin-top:10px;
@@ -76,11 +75,11 @@
     }
   </style>
 
-  <section id="headline" class="container">
+  <section id="headline" class="container-fluid">
     <div class="row">
       <div class="col-lg-12 text-center">
         <h1>
-          <a class="btn btn-primary btn-circle pull-left" href="/documentation" type="button" style="padding: 4px 0">
+          <a class="btn btn-primary btn-circle pull-left" data-dismiss="modal" type="button" style="padding: 4px 0">
             <i class="fa fa-arrow-left"></i>
           </a>
           <span>${title}</span>
@@ -110,5 +109,4 @@
       });
     });
   </script>
-  </@default>
 </#macro>


### PR DESCRIPTION
Couple changes:

- Upgrade spring boot version and blossom version (using snapshot while waiting for 1.1.0 release)
- Open documentation subpages in modals instead of reloading the page each time